### PR TITLE
[GO docs] Modified the "MailjetAttachment" to "Attachment"

### DIFF
--- a/guides/_send-api.md
+++ b/guides/_send-api.md
@@ -680,8 +680,8 @@ func main () {
           Email: "passenger@mailjet.com",
         },
       },
-      Attachments: []MailjetAttachment {
-        MailjetAttachment {
+      Attachments: []Attachment {
+        Attachment {
           ContentType: "text/plain",
           Filename: "test.txt",
           Content: "VGhpcyBpcyB5b3VyIGF0dGFjaGVkIGZpbGUhISEK",


### PR DESCRIPTION
This part of the documentation is out of date compared to the actual lib. It refers to `MailjetAttachment` instead of `Attachment` which is the correct name of the struct :).

I've investigated a little and I've found the commit in which this change was made on the code of the lib.

https://github.com/mailjet/mailjet-apiv3-go/commit/0a22affb8bf4cb236011fe7ad005806a8310ad3f#diff-14a751520174bf37c6d5f007451ef211L77

https://github.com/mailjet/mailjet-apiv3-go/commit/0a22affb8bf4cb236011fe7ad005806a8310ad3f#diff-14a751520174bf37c6d5f007451ef211L99

BTW, work perfectly ;)