### PR TITLE
MJ-TemplateLanguage is lowercase "j" for node

### DIFF
--- a/guides/_send-api.md
+++ b/guides/_send-api.md
@@ -2194,7 +2194,7 @@ var request = mailjet
 		"FromName":"Mailjet Pilot",
 		"Subject":"Your email flight plan!",
 		"MJ-TemplateID":"1",
-		"MJ-TemplateLanguage":"true",
+		"Mj-TemplateLanguage":"true",
 		"Recipients":[
 				{
 						"Email": "passenger@mailjet.com"


### PR DESCRIPTION
see here https://dev.mailjet.com/template-language/sendapi/#templates-error-management