### PR TITLE
FIX: fixes documentation issue that states that template id is a string

### DIFF
--- a/guides/_send-api.md
+++ b/guides/_send-api.md
@@ -3136,7 +3136,7 @@ public class MyClass {
                         .put(new JSONObject()
                             .put("Email", "passenger1@mailjet.com")
                             .put("Name", "passenger 1")))
-                    .put(Emailv31.Message.TEMPLATEID, "1")
+                    .put(Emailv31.Message.TEMPLATEID, 1)
                     .put(Emailv31.Message.TEMPLATELANGUAGE, true)
                     .put(Emailv31.Message.SUBJECT, "Your email flight plan!")));
       response = client.post(request);


### PR DESCRIPTION
Hi, 
based on your api-reference an integer is required for sending mails with a template id. The documentation states a string here, which will result in a Bad-Request response from your api. 

Reference: https://dev.mailjet.com/email/reference/send-emails/
![grafik](https://user-images.githubusercontent.com/5542725/83939341-72ddbe80-a7dc-11ea-9399-6af32a7a9508.png)

This just simply fixes the documentation for this particular part. :)

